### PR TITLE
Remove unnecessary includes from Build

### DIFF
--- a/Plugins/rtik/Source/rtik/rtik.Build.cs
+++ b/Plugins/rtik/Source/rtik/rtik.Build.cs
@@ -12,9 +12,9 @@ public class rtik : ModuleRules
 
         PrivateDependencyModuleNames.AddRange(new string[] {  });
 
-        PublicIncludePaths.AddRange(new string[] { "rtik/Public", "rtik/Public/IK", "rtik/Public/Utility" });
+        // PublicIncludePaths.AddRange(new string[] { "rtik/Public", "rtik/Public/IK", "rtik/Public/Utility" });
 
-        PrivateIncludePaths.AddRange(new string[] { "rtik/Private", "rtik/Private/IK", "rtik/Private/Utility"});
+        // PrivateIncludePaths.AddRange(new string[] { "rtik/Private", "rtik/Private/IK", "rtik/Private/Utility"});
 
 		// Uncomment if you are using Slate UI
 		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });

--- a/Plugins/rtik/Source/rtikEditor/rtikEditor.Build.cs
+++ b/Plugins/rtik/Source/rtikEditor/rtikEditor.Build.cs
@@ -13,9 +13,9 @@ public class rtikEditor : ModuleRules
 
         PrivateDependencyModuleNames.AddRange(new string[] { "EditorStyle", "AnimGraph", "BlueprintGraph", "PropertyEditor", "Slate", "SlateCore" });
 
-        PublicIncludePaths.AddRange(new string[] { "rtikEditor/Public", "rtikEditor/Public/GraphNodes" });
+        // PublicIncludePaths.AddRange(new string[] { "rtikEditor/Public", "rtikEditor/Public/GraphNodes" });
 
-        PrivateIncludePaths.AddRange(new string[] { "rtikEditor/Private", "rtikEditor/Private/GraphNodes" });
+        // PrivateIncludePaths.AddRange(new string[] { "rtikEditor/Private", "rtikEditor/Private/GraphNodes" });
 
         // Uncomment if you are using Slate UI
         // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });


### PR DESCRIPTION
Including the plugin's own files in the build script results in 4.20 errors, as it looks for them in the Engine directory.