### PR TITLE
Add missing GetNode functions

### DIFF
--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidArmTorsoAdjust.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidArmTorsoAdjust.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;

--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidFootRotationController.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidFootRotationController.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;

--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidLegIK.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidLegIK.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;

--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidLegIKKneeCorrection.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidLegIKKneeCorrection.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;

--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidPelvisHeightAdjustment.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_HumanoidPelvisHeightAdjustment.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;

--- a/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_IKHumanoidLegTrace.h
+++ b/Plugins/rtik/Source/rtikEditor/Public/GraphNodes/AnimGraphNode_IKHumanoidLegTrace.h
@@ -16,6 +16,7 @@ public:
 	FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	FLinearColor GetNodeTitleColor() const override;
 	FString GetNodeCategory() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
 
 protected:
 	virtual FText GetControllerDescription() const;


### PR DESCRIPTION
GetNodes are currently not overridden, resulting a `LowLevelFatalError` when querying the Node, as SkeletalControlBase.h returns a `nullptr` as default.
This PR fixes this issue by properly returning the Node.